### PR TITLE
ENH: Allow one to get a specified number of generations of ancestors or descendants.

### DIFF
--- a/refcycle/directed_graph.py
+++ b/refcycle/directed_graph.py
@@ -179,38 +179,58 @@ class DirectedGraph(object):
         """
         return [self.tails[edge] for edge in self._in_edges[start]]
 
-    def descendants(self, start):
+    def descendants(self, start, ngenerations=None):
         """
         Return the subgraph of all nodes reachable
         from the given start vertex.
 
         """
         visited = set()
-        to_visit = [start]
-        while to_visit:
-            vertex = to_visit.pop()
-            visited.add(vertex)
-            for edge in self._out_edges[vertex]:
-                head = self.heads[edge]
-                if head not in visited:
-                    to_visit.append(head)
+        if ngenerations is None:
+            to_visit = [start]
+            while to_visit:
+                vertex = to_visit.pop()
+                visited.add(vertex)
+                for edge in self._out_edges[vertex]:
+                    head = self.heads[edge]
+                    if head not in visited:
+                        to_visit.append(head)
+        else:
+            generation = [start]
+            for i in range(ngenerations+1):
+                children = []
+                for item in generation:
+                    if item not in visited:
+                        visited.add(item)
+                        children.extend(self.children(item))
+                generation = children
         return self.complete_subgraph_on_vertices(visited)
 
-    def ancestors(self, start):
+    def ancestors(self, start, ngenerations=None):
         """
         Return the subgraph of all nodes from which the
         given vertex is reachable.
 
         """
         visited = set()
-        to_visit = [start]
-        while to_visit:
-            vertex = to_visit.pop()
-            visited.add(vertex)
-            for edge in self._in_edges[vertex]:
-                tail = self.tails[edge]
-                if tail not in visited:
-                    to_visit.append(tail)
+        if ngenerations is None:
+            to_visit = [start]
+            while to_visit:
+                vertex = to_visit.pop()
+                visited.add(vertex)
+                for edge in self._in_edges[vertex]:
+                    tail = self.tails[edge]
+                    if tail not in visited:
+                        to_visit.append(tail)
+        else:
+            generation = [start]
+            for i in range(ngenerations+1):
+                parents = []
+                for item in generation:
+                    if item not in visited:
+                        visited.add(item)
+                        parents.extend(self.parents(item))
+                generation = parents
         return self.complete_subgraph_on_vertices(visited)
 
     def strongly_connected_components(self):

--- a/refcycle/object_graph.py
+++ b/refcycle/object_graph.py
@@ -203,7 +203,7 @@ class ObjectGraph(object):
             for ref_id in self._id_digraph.parents(id(obj))
         ]
 
-    def descendants(self, obj):
+    def descendants(self, obj, ngenerations=None):
         """
         Get the collection of all objects reachable from a particular
         id.
@@ -211,17 +211,17 @@ class ObjectGraph(object):
         """
         return ObjectGraph._raw(
             id_to_object=self._id_to_object,
-            id_digraph=self._id_digraph.descendants(id(obj)),
+            id_digraph=self._id_digraph.descendants(id(obj), ngenerations=ngenerations),
         )
 
-    def ancestors(self, obj):
+    def ancestors(self, obj, ngenerations=None):
         """
         Return the subgraph of ancestors of the given object.
 
         """
         return ObjectGraph._raw(
             id_to_object=self._id_to_object,
-            id_digraph=self._id_digraph.ancestors(id(obj)),
+            id_digraph=self._id_digraph.ancestors(id(obj), ngenerations=ngenerations),
         )
 
     def strongly_connected_components(self):


### PR DESCRIPTION
It's ugly code, but it helped me recently trying to answer "Who is holding onto this object?" interactively. When everything should have been cleaned up but certain objects of interest were still in `gc.get_objects()`, I would drop into an embedded IPython shell with the graph loaded up. I could then slowly increase the number of generations back from my errant objects until I understood where they were ultimately coming from.
