### PR TITLE
Allow limiting of generations in the 'descendants' and 'ancestors' methods.

### DIFF
--- a/refcycle/i_directed_graph.py
+++ b/refcycle/i_directed_graph.py
@@ -76,44 +76,54 @@ class IDirectedGraph(object):
             for head in self.children(tail)
         ]
 
-    def descendants(self, start):
+    def descendants(self, start, generations=None):
         """
         Return the subgraph of all nodes reachable
         from the given start vertex.
 
+        If specified, the optional `generations` arguments specifies how
+        many generations to limit to.
+
         """
         id = self.id_map
 
         visited = set()
         stack = []
-        to_visit = [start]
+        to_visit = [(start, 0)]
         while to_visit:
-            vertex = to_visit.pop()
+            vertex, depth = to_visit.pop()
+            if generations is not None and depth > generations:
+                continue
             stack.append(vertex)
             visited.add(id(vertex))
             for head in self.children(vertex):
                 if id(head) not in visited:
-                    to_visit.append(head)
+                    to_visit.append((head, depth+1))
         return self.complete_subgraph_on_vertices(stack)
 
-    def ancestors(self, start):
+    def ancestors(self, start, generations=None):
         """
         Return the subgraph of all nodes from which the given vertex is
         reachable.
+
+        If specified, the optional `generations` arguments specifies how
+        many generations to limit to.
 
         """
         id = self.id_map
 
         visited = set()
         stack = []
-        to_visit = [start]
+        to_visit = [(start, 0)]
         while to_visit:
-            vertex = to_visit.pop()
+            vertex, depth = to_visit.pop()
+            if generations is not None and depth > generations:
+                continue
             stack.append(vertex)
             visited.add(id(vertex))
             for head in self.parents(vertex):
                 if id(head) not in visited:
-                    to_visit.append(head)
+                    to_visit.append((head, depth+1))
         return self.complete_subgraph_on_vertices(stack)
 
     def strongly_connected_components(self):

--- a/refcycle/test/test_directed_graph.py
+++ b/refcycle/test/test_directed_graph.py
@@ -99,6 +99,48 @@ class TestDirectedGraph(unittest.TestCase):
         sccs = graph.strongly_connected_components()
         self.assertEqual(len(sccs), 1)
 
+    def test_limited_descendants(self):
+        graph = graph_from_string(
+            "1 2 3 4 5 6; 1->2 1->3 2->3 2->4 4->3 4->5 5->2 5->6 6->3 6->4")
+
+        self.assertItemsEqual(
+            graph.descendants('1', generations=0),
+            ['1'],
+        )
+        self.assertItemsEqual(
+            graph.descendants('1', generations=1),
+            ['1', '2', '3'],
+        )
+        self.assertItemsEqual(
+            graph.descendants('1', generations=2),
+            ['1', '2', '3', '4'],
+        )
+        self.assertItemsEqual(
+            graph.descendants('1', generations=3),
+            ['1', '2', '3', '4', '5'],
+        )
+
+    def test_limited_ancestors(self):
+        graph = graph_from_string(
+            "1 2 3 4 5 6; 1->2 1->3 2->3 2->4 4->3 4->5 5->2 5->6 6->3 6->4")
+
+        self.assertItemsEqual(
+            graph.ancestors('3', generations=0),
+            ['3'],
+        )
+        self.assertItemsEqual(
+            graph.ancestors('3', generations=1),
+            ['1', '2', '3', '4', '6'],
+        )
+        self.assertItemsEqual(
+            graph.ancestors('3', generations=2),
+            ['1', '2', '3', '4', '5', '6'],
+        )
+        self.assertItemsEqual(
+            graph.ancestors('3', generations=3),
+            ['1', '2', '3', '4', '5', '6'],
+        )
+
     def test_length(self):
         self.assertEqual(len(test_graph), 11)
 


### PR DESCRIPTION
(Suggested by Robert Kern.  Reworking of PR #1.)
