### PR TITLE
Make ObjectGraph(iterator) safe; don't use .values, .items, .keys

### DIFF
--- a/refcycle/__init__.py
+++ b/refcycle/__init__.py
@@ -136,7 +136,7 @@ def objects_reachable_from(obj):
         for ref in refs:
             if id(ref) not in found:
                 to_process.append(ref)
-    return ObjectGraph(found.values())
+    return ObjectGraph(found.itervalues())
 
 
 def _is_orphan(scc, graph):

--- a/refcycle/object_graph.py
+++ b/refcycle/object_graph.py
@@ -81,7 +81,7 @@ class ObjectGraph(IDirectedGraph):
         Return list of vertices of the graph.
 
         """
-        return self._id_to_object.values()
+        return list(self._id_to_object.itervalues())
 
     def complete_subgraph_on_vertices(self, vertices):
         """
@@ -161,8 +161,7 @@ class ObjectGraph(IDirectedGraph):
         out_edges = collections.defaultdict(list)
         in_edges = collections.defaultdict(list)
 
-        for referrer in objects:
-            referrer_id = id(referrer)
+        for referrer_id, referrer in id_to_object.iteritems():
             for referent in gc.get_referents(referrer):
                 referent_id = id(referent)
                 if referent_id not in id_to_object:
@@ -322,5 +321,7 @@ class ObjectGraph(IDirectedGraph):
                 self._tail,
                 self._out_edges,
                 self._in_edges,
-            ] + self._out_edges.values() + self._in_edges.values()
+            ] +
+            list(self._out_edges.itervalues()) +
+            list(self._in_edges.itervalues())
         )

--- a/refcycle/test/test_object_graph.py
+++ b/refcycle/test/test_object_graph.py
@@ -49,6 +49,18 @@ class TestObjectGraph(unittest.TestCase):
             [(a, b)],
         )
 
+    def test_construction_from_iterator(self):
+        a = [0]
+        b = [1]
+        a.append(b)
+        b.append(a)
+        objects = iter([a, b, a[0], b[0]])
+        graph = ObjectGraph(objects)
+        self.assertEqual(len(graph), 4)
+        # Check that we get all the edges we expect.
+        self.assertEqual(len(graph.children(a)), 2)
+        self.assertEqual(len(graph.children(b)), 2)
+
     def test_self_reference(self):
         a = [0]
         a.append(a)


### PR DESCRIPTION
In preparation for updating code to work with Python 3:  don't use dict.values, dict.keys, dict.items anywhere;  use the dict.iter\* variants instead.

Also make it safe to create an `ObjectGraph` from an iteration;  the previous code for the `ObjectGraph` constructor needlessly iterated through its input twice.
