### PR TITLE
Fix slow full_subgraph.

### DIFF
--- a/refcycle/annotated_graph.py
+++ b/refcycle/annotated_graph.py
@@ -155,15 +155,15 @@ class AnnotatedGraph(IDirectedGraph):
         of the original graph between those vertices.
 
         """
-        vertex_ids = {vertex.id for vertex in vertices}
+        obj_map = {vertex.id: vertex for vertex in vertices}
         edges = [
-            edge for edge in self._edges
-            if edge.tail in vertex_ids
-            if edge.head in vertex_ids
+            edge for vertex_id in obj_map
+            for edge in self._out_edges[vertex_id]
+            if edge.head in obj_map
         ]
 
         return AnnotatedGraph(
-            vertices=vertices,
+            vertices=obj_map.values(),
             edges=edges,
         )
 


### PR DESCRIPTION
`AnnotatedGraph.full_subgraph` currently iterates over _all_ graph edges, which is inefficient for large graphs.  In particular, that makes `strongly_connected_components` noticeably slow for graphs of more than a few thousand vertices.

Fixes #24.

This is really just a stopgap measure;  the correct fix is to get the edge information directly from the `strongly_connected_components` algorithm, and add a simple `subgraph` operation that takes the vertices _and_ the edges of the subgraph as input.
