### PR TITLE
Fix depth limited searches in `ancestors` and `descendants` methods.

### DIFF
--- a/refcycle/i_directed_graph.py
+++ b/refcycle/i_directed_graph.py
@@ -16,7 +16,7 @@ Abstract base class for the various flavours of directed graph.
 
 """
 import abc
-from collections import Container, Iterable, Sized
+from collections import Container, Iterable, Sized, deque
 
 
 class IDirectedGraph(Container, Iterable, Sized):
@@ -164,19 +164,16 @@ class IDirectedGraph(Container, Iterable, Sized):
 
         """
         visited = self.vertex_set()
-        stack = []
-        to_visit = [(start, 0)]
+        to_visit = deque([(start, 0)])
         while to_visit:
-            vertex, depth = to_visit.pop()
-            if generations is not None and depth > generations:
-                continue
-            stack.append(vertex)
+            vertex, depth = to_visit.popleft()
             visited.add(vertex)
-            to_visit.extend(
-                (child, depth+1) for child in self.children(vertex)
-                if child not in visited
-            )
-        return self.full_subgraph(stack)
+            if generations is None or depth < generations:
+                to_visit.extend(
+                    (child, depth+1) for child in self.children(vertex)
+                    if child not in visited
+                )
+        return self.full_subgraph(visited)
 
     def ancestors(self, start, generations=None):
         """
@@ -188,19 +185,16 @@ class IDirectedGraph(Container, Iterable, Sized):
 
         """
         visited = self.vertex_set()
-        stack = []
-        to_visit = [(start, 0)]
+        to_visit = deque([(start, 0)])
         while to_visit:
-            vertex, depth = to_visit.pop()
-            if generations is not None and depth > generations:
-                continue
-            stack.append(vertex)
+            vertex, depth = to_visit.popleft()
             visited.add(vertex)
-            to_visit.extend(
-                (parent, depth+1) for parent in self.parents(vertex)
-                if parent not in visited
-            )
-        return self.full_subgraph(stack)
+            if generations is None or depth < generations:
+                to_visit.extend(
+                    (parent, depth+1) for parent in self.parents(vertex)
+                    if parent not in visited
+                )
+        return self.full_subgraph(visited)
 
     def strongly_connected_components(self):
         """

--- a/refcycle/test/test_directed_graph.py
+++ b/refcycle/test/test_directed_graph.py
@@ -136,6 +136,36 @@ class TestDirectedGraph(unittest.TestCase):
             ['1', '2', '3', '4', '5'],
         )
 
+    def test_more_limited_descendants(self):
+        # Regression test for issue #30 on GitHub.  Note that 4 is at depth 2,
+        # but with a depth-first search it's likely that the first visit to it
+        # will be at depth 3.  So when searching with generations=3, we don't
+        # bother looking at the children of 4, so we miss 8.
+        graph = graph_from_string(
+            "1 2 3 4 5 6 7 8; 1->2->3->4->8 1->5->4 1->6->7->4"
+        )
+
+        self.assertCountEqual(
+            graph.descendants('1', generations=0),
+            ['1'],
+        )
+        self.assertCountEqual(
+            graph.descendants('1', generations=1),
+            list('1256'),
+        )
+        self.assertCountEqual(
+            graph.descendants('1', generations=2),
+            list('1234567'),
+        )
+        self.assertCountEqual(
+            graph.descendants('1', generations=3),
+            list('12345678'),
+        )
+        self.assertCountEqual(
+            graph.descendants('1', generations=4),
+            list('12345678'),
+        )
+
     def test_limited_ancestors(self):
         graph = graph_from_string(
             "1 2 3 4 5 6; 1->2 1->3 2->3 2->4 4->3 4->5 5->2 5->6 6->3 6->4")


### PR DESCRIPTION
The `ancestors` and `descendants` were missing some nodes when working with limited generations; use breadth-first search instead of depth-first to fix this.

Fixes #30.
