### PR TITLE
Add Python 3.4 and Python 3.5 to Travis CI test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - 2.7
   - 3.3
+  - 3.4
+  - 3.5
 install:
   - python setup.py develop
 script:


### PR DESCRIPTION
Run tests on Python 3.4 and Python 3.5 as well as earlier versions.