### PR TITLE
In Python 2, support annotation of bound methods with no im_class.

### DIFF
--- a/refcycle/annotations.py
+++ b/refcycle/annotations.py
@@ -175,8 +175,13 @@ def object_annotation(obj):
         return "function\\n{}".format(obj.__name__)
     elif isinstance(obj, types.MethodType):
         if six.PY2:
+            im_class = obj.im_class
+            if im_class is None:
+                im_class_name = "<None>"
+            else:
+                im_class_name = im_class.__name__
             return "instancemethod\\n{}.{}".format(
-                obj.im_class.__name__,
+                im_class_name,
                 obj.__func__.__name__,
             )
         else:

--- a/refcycle/test/test_annotations.py
+++ b/refcycle/test/test_annotations.py
@@ -15,6 +15,7 @@ import gc
 import inspect
 import sys
 import unittest
+import types
 import weakref
 
 import six
@@ -300,6 +301,19 @@ class TestObjectAnnotations(unittest.TestCase):
             object_annotation(method),
             "instancemethod\\nNewStyle.foo",
         )
+
+    if six.PY2:
+        def test_annotate_instancemethod_without_class(self):
+            # In Python 2, it's possible to create bound methods
+            # without an im_class attribute.
+            def my_method(self):
+                return 42
+
+            method = types.MethodType(my_method, NewStyle())
+            self.assertEqual(
+                object_annotation(method),
+                "instancemethod\\n<None>.my_method",
+            )
 
     def test_annotate_weakref(self):
         a = set()


### PR DESCRIPTION
This PR resolves a Python 2 only issue where annotation failed for bound method objects whose `im_class` attribute was `None`.

The actual object that this failed on was an IPython `InteractiveShell.pre_prompt_hook` method, but it's possible to create such bound methods using `types.MethodType`, by omitting the third argument.