### PR TITLE
Fix a test that was only passing accidentally.

### DIFF
--- a/refcycle/test/test_annotations.py
+++ b/refcycle/test/test_annotations.py
@@ -87,7 +87,7 @@ class TestEdgeAnnotations(unittest.TestCase):
 
     def test_annotate_frozenset(self):
         a, b, c = 1, 2, 3
-        s = frozenset([1, 2, 3])
+        s = frozenset([a, b, c])
         self.check_description(s, a, "element")
         self.check_description(s, b, "element")
         self.check_completeness(s)


### PR DESCRIPTION
This test only passed because the `1`, `2` and `3` literals in the second line of the test happened to resolve to the same objects as the corresponding literals in the first line.