### PR TITLE
Fix quadratic-time behaviour in DirectedGraph.full_subgraph.

### DIFF
--- a/refcycle/directed_graph.py
+++ b/refcycle/directed_graph.py
@@ -102,9 +102,9 @@ class DirectedGraph(IDirectedGraph):
         """
         subgraph_vertices = {v for v in vertices}
         subgraph_edges = {edge
-                          for v in vertices
+                          for v in subgraph_vertices
                           for edge in self._out_edges[v]
-                          if self._heads[edge] in vertices}
+                          if self._heads[edge] in subgraph_vertices}
         subgraph_heads = {edge: self._heads[edge]
                           for edge in subgraph_edges}
         subgraph_tails = {edge: self._tails[edge]

--- a/refcycle/test/test_directed_graph.py
+++ b/refcycle/test/test_directed_graph.py
@@ -257,6 +257,38 @@ class TestDirectedGraph(unittest.TestCase):
         self.assertCountEqual(vertices, [1, 2, 3, 4, 5])
         self.assertEqual(len(edges), 5)
 
+    def test_full_subgraph_large_from_list(self):
+        # An earlier version of full_subgraph had quadratic-time behaviour.
+        vertex_count = 20000
+        vertices = set(range(vertex_count))
+        edge_mapper = {
+            n: [(n + 1) % vertex_count, (n + 1) % vertex_count]
+            for n in vertices
+        }
+        graph = DirectedGraph.from_out_edges(
+            vertices=vertices,
+            edge_mapper=edge_mapper,
+        )
+        subgraph = graph.full_subgraph(list(vertices))
+        self.assertEqual(len(subgraph.vertices), len(graph.vertices))
+        self.assertEqual(len(subgraph.edges), len(graph.edges))
+
+    def test_full_subgraph_from_iterator(self):
+        # Should be fine to create a subgraph from an iterator.
+        vertex_count = 100
+        vertices = set(range(vertex_count))
+        edge_mapper = {
+            n: [(n + 1) % vertex_count, (n + 1) % vertex_count]
+            for n in vertices
+        }
+        graph = DirectedGraph.from_out_edges(
+            vertices=vertices,
+            edge_mapper=edge_mapper,
+        )
+        subgraph = graph.full_subgraph(iter(vertices))
+        self.assertEqual(len(subgraph.vertices), len(graph.vertices))
+        self.assertEqual(len(subgraph.edges), len(graph.edges))
+
     def test_to_dot(self):
         dot = test_graph.to_dot()
         self.assertIsInstance(dot, six.text_type)


### PR DESCRIPTION
The DirectedGraph.full_subgraph method behaved poorly when given a large list as input. It also failed when given vertices in a iterator. This PR fixes both issues.