### PR TITLE
New convenience features: shortest_cycle, find_by_typename, count_by_typename

### DIFF
--- a/refcycle/i_directed_graph.py
+++ b/refcycle/i_directed_graph.py
@@ -16,7 +16,7 @@ Abstract base class for the various flavours of directed graph.
 
 """
 import abc
-from collections import Container, Counter, Iterable, Sized, deque
+from collections import Container, Counter, deque, Iterable, Sized
 
 import logging
 logger = logging.getLogger(__name__)

--- a/refcycle/i_directed_graph.py
+++ b/refcycle/i_directed_graph.py
@@ -18,9 +18,6 @@ Abstract base class for the various flavours of directed graph.
 import abc
 from collections import Container, Counter, deque, Iterable, Sized
 
-import logging
-logger = logging.getLogger(__name__)
-
 
 class IDirectedGraph(Container, Iterable, Sized):
     """

--- a/refcycle/i_directed_graph.py
+++ b/refcycle/i_directed_graph.py
@@ -252,7 +252,7 @@ class IDirectedGraph(Container, Iterable, Sized):
         """
         Find a shortest cycle including start.
 
-        Returns the subgraph consisting of the vertices in that path
+        Returns the subgraph consisting of the vertices in that cycle
         and (all) the edges between them.
 
         Raises ValueError if no cycle including start exists.

--- a/refcycle/i_directed_graph.py
+++ b/refcycle/i_directed_graph.py
@@ -100,7 +100,7 @@ class IDirectedGraph(Container, Iterable, Sized):
         return dict()
 
     @classmethod
-    def _vertex_equal(cls, vertex1, vertex2):
+    def vertex_equal(cls, vertex1, vertex2):
         """
         Criterion to use to determine whether two vertices are equal.
 
@@ -282,7 +282,7 @@ class IDirectedGraph(Container, Iterable, Sized):
         while True:
             path.append(vertex)
             vertex = explored[vertex]
-            if self._vertex_equal(vertex, start):
+            if self.vertex_equal(vertex, start):
                 break
 
         return self.full_subgraph(path)

--- a/refcycle/i_directed_graph.py
+++ b/refcycle/i_directed_graph.py
@@ -411,8 +411,6 @@ class IDirectedGraph(Container, Iterable, Sized):
 
         return [self.full_subgraph(scc) for scc in sccs]
 
-    # XXX Needs tests.
-
     def count_by(self, classifier):
         """
         Return a count of objects using the given classifier.
@@ -423,9 +421,7 @@ class IDirectedGraph(Container, Iterable, Sized):
 
         Returns a collections.Counter instance mapping classes to counts.
         """
-        return collections.Counter(classifier(obj) for obj in self)
-
-    # XXX Needs tests.
+        return Counter(classifier(obj) for obj in self)
 
     def find_by(self, predicate):
         """

--- a/refcycle/object_graph.py
+++ b/refcycle/object_graph.py
@@ -15,6 +15,7 @@
 Tools to analyze the Python object graph and find reference cycles.
 
 """
+import collections
 import gc
 import itertools
 
@@ -341,6 +342,10 @@ class ObjectGraph(IDirectedGraph):
         """
         return self.annotated().to_dot()
 
+    ###########################################################################
+    ### Other utility methods.
+    ###########################################################################
+
     def owned_objects(self):
         """
         List of gc-tracked objects owned by this ObjectGraph instance.
@@ -365,3 +370,22 @@ class ObjectGraph(IDirectedGraph):
             list(six.itervalues(self._out_edges)) +
             list(six.itervalues(self._in_edges))
         )
+
+    # XXX Needs tests.
+
+    def find_by_typename(self, typename):
+        """
+        List of all objects whose type has the given name.
+        """
+        return self.findby(lambda obj: type(obj).__name__ == typename)
+
+    # XXX Needs tests.
+
+    def count_by_typename(self):
+        """
+        Classify objects by type name.
+
+        Returns a collections.Counter instance mapping type names to the number
+        of objects with that typename.
+        """
+        return self.count_by(lambda obj: type(obj).__name)

--- a/refcycle/object_graph.py
+++ b/refcycle/object_graph.py
@@ -15,7 +15,6 @@
 Tools to analyze the Python object graph and find reference cycles.
 
 """
-import collections
 import gc
 import itertools
 
@@ -375,15 +374,11 @@ class ObjectGraph(IDirectedGraph):
             list(six.itervalues(self._in_edges))
         )
 
-    # XXX Needs tests.
-
     def find_by_typename(self, typename):
         """
         List of all objects whose type has the given name.
         """
         return self.find_by(lambda obj: type(obj).__name__ == typename)
-
-    # XXX Needs tests.
 
     def count_by_typename(self):
         """
@@ -392,4 +387,4 @@ class ObjectGraph(IDirectedGraph):
         Returns a collections.Counter instance mapping type names to the number
         of objects with that typename.
         """
-        return self.count_by(lambda obj: type(obj).__name)
+        return self.count_by(lambda obj: type(obj).__name__)

--- a/refcycle/object_graph.py
+++ b/refcycle/object_graph.py
@@ -381,10 +381,10 @@ class ObjectGraph(IDirectedGraph):
         return self.find_by(lambda obj: type(obj).__name__ == typename)
 
     def count_by_typename(self):
-        """
-        Classify objects by type name.
+        """Classify objects by type name.
 
         Returns a collections.Counter instance mapping type names to the number
-        of objects with that typename.
+        of objects `obj` in this graph for which `type(obj).__name__` matches
+        that type name.
         """
         return self.count_by(lambda obj: type(obj).__name__)

--- a/refcycle/object_graph.py
+++ b/refcycle/object_graph.py
@@ -171,7 +171,7 @@ class ObjectGraph(IDirectedGraph):
         return KeyTransformDict(transform=id)
 
     @classmethod
-    def _vertex_equal(cls, vertex1, vertex2):
+    def vertex_equal(cls, vertex1, vertex2):
         return vertex1 is vertex2
 
     ###########################################################################

--- a/refcycle/object_graph.py
+++ b/refcycle/object_graph.py
@@ -381,7 +381,7 @@ class ObjectGraph(IDirectedGraph):
         """
         List of all objects whose type has the given name.
         """
-        return self.findby(lambda obj: type(obj).__name__ == typename)
+        return self.find_by(lambda obj: type(obj).__name__ == typename)
 
     # XXX Needs tests.
 

--- a/refcycle/object_graph.py
+++ b/refcycle/object_graph.py
@@ -171,6 +171,10 @@ class ObjectGraph(IDirectedGraph):
     def vertex_dict(cls):
         return KeyTransformDict(transform=id)
 
+    @classmethod
+    def _vertex_equal(cls, vertex1, vertex2):
+        return vertex1 is vertex2
+
     ###########################################################################
     ### ObjectGraph constructors.
     ###########################################################################

--- a/refcycle/test/test_object_graph.py
+++ b/refcycle/test/test_object_graph.py
@@ -247,7 +247,7 @@ class TestObjectGraph(unittest.TestCase):
         graph = ObjectGraph([a, b, c, d, e, f])
         path = graph.shortest_path(a, f)
         self.assertIsInstance(path, IDirectedGraph)
-        self.assertEqual(len(path.vertices), 3)
+        self.assertEqual(len(path), 3)
 
         self.assertIn(a, path.vertices)
         self.assertIn(c, path.vertices)
@@ -269,10 +269,62 @@ class TestObjectGraph(unittest.TestCase):
         a.append(b)
         b.append(a)
         a.append(a)
-        graph = ObjectGraph([a])
+        graph = ObjectGraph([a, b])
         path = graph.shortest_path(a, a)
         self.assertIsInstance(path, IDirectedGraph)
-        self.assertEqual(len(path.vertices), 1)
+        self.assertEqual(len(path), 1)
+
+    def test_shortest_cycle(self):
+        a = []
+        b = []
+        a.append(b)
+        b.append(a)
+        graph = ObjectGraph([a, b])
+        cycle = graph.shortest_cycle(a)
+        self.assertIsInstance(cycle, IDirectedGraph)
+        self.assertEqual(len(cycle), 2)
+
+    def test_shortest_cycle_self_cycle(self):
+        a = []
+        b = []
+        c = []
+        a.append(b)
+        b.append(b)
+        b.append(c)
+        c.append(a)
+        graph = ObjectGraph([a, b, c])
+        cycle = graph.shortest_cycle(b)
+        self.assertIsInstance(cycle, IDirectedGraph)
+        self.assertEqual(len(cycle), 1)
+
+    def test_shortest_cycle_no_cycle(self):
+        a = []
+        b = []
+        c = []
+        b.append(c)
+        c.append(b)
+        a.append(b)
+        graph = ObjectGraph([a, b, c])
+        with self.assertRaises(ValueError):
+            graph.shortest_cycle(a)
+
+    def test_shortest_cycle_many_cycles(self):
+        a, b, c, d, e = objs = [[] for _ in range(5)]
+        a.append(b)
+        b.append(c)
+        c.append(a)
+        b.append(d)
+        d.append(a)
+        b.append(e)
+        e.append(d)
+        graph = ObjectGraph(objs)
+        cycle = graph.shortest_cycle(a)
+        self.assertIsInstance(cycle, IDirectedGraph)
+        self.assertEqual(len(cycle), 3)
+        self.assertIn(a, cycle)
+        self.assertIn(b, cycle)
+        # Exactly one of c and d should be in the cycle.
+        self.assertEqual((c in cycle) + (d in cycle), 1)
 
     def test_to_dot(self):
         a = []

--- a/refcycle/test/test_object_graph.py
+++ b/refcycle/test/test_object_graph.py
@@ -326,6 +326,29 @@ class TestObjectGraph(unittest.TestCase):
         # Exactly one of c and d should be in the cycle.
         self.assertEqual((c in cycle) + (d in cycle), 1)
 
+    def test_count_by_typename(self):
+        a, b, c = [], [], []
+        d, e = set(), set()
+        f = {}
+        graph = ObjectGraph([a, b, c, d, e, f])
+        counts = graph.count_by_typename()
+        self.assertIsInstance(counts, collections.Counter)
+        self.assertEqual(
+            dict(counts),
+            dict(list=3, set=2, dict=1),
+        )
+
+    def test_find_by_typename(self):
+        a, b, c = [], [], []
+        d, e = set(), set()
+        f = {}
+        graph = ObjectGraph([a, b, c, d, e, f])
+
+        sets = graph.find_by_typename('set')
+        self.assertEqual(len(sets), 2)
+        self.assertIn(d, sets)
+        self.assertIn(e, sets)
+
     def test_to_dot(self):
         a = []
         b = []


### PR DESCRIPTION
This PR adds a few new `ObjectGraph` methods:

- `shortest_cycle` finds a shortest cycle starting and ending at the given node; this can be helpful in analysing cyclic garbage without having to examine the entire strongly connected component of the node
- `find_by_typename` simply extracts all objects whose `type` has a given `__name__`
- `count_by_typename` returns counts of the whole graph by typename.