### PR TITLE
Add GitHub Actions workflow to run unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - run: python -m pip install .
+    - run: mkdir testdir && cd testdir && python -m unittest discover -v refcycle

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+      fail-fast: false
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This PR adds a simple GitHub Actions workflow to run the unit tests on Python 3.7 through Python 3.12.