### PR TITLE
Fix imports from collections that need to be from collections.abc

### DIFF
--- a/refcycle/element_transform_set.py
+++ b/refcycle/element_transform_set.py
@@ -17,7 +17,7 @@ internal storage, allowing non-hashable objects to be stored
 efficiently.
 
 """
-from collections import MutableSet
+from collections.abc import MutableSet
 
 import six
 

--- a/refcycle/i_directed_graph.py
+++ b/refcycle/i_directed_graph.py
@@ -16,7 +16,8 @@ Abstract base class for the various flavours of directed graph.
 
 """
 import abc
-from collections import Container, Counter, deque, Iterable, Sized
+from collections import Counter, deque
+from collections.abc import Container, Iterable, Sized
 
 
 class IDirectedGraph(Container, Iterable, Sized):

--- a/refcycle/key_transform_dict.py
+++ b/refcycle/key_transform_dict.py
@@ -19,12 +19,12 @@ Similar to, and partly inspired by, Antoine Pitrou's TransformDict
 implementation (bugs.python.org/issue18986).
 
 """
-import collections
+import collections.abc
 
 import six
 
 
-class KeyTransformDict(collections.MutableMapping):
+class KeyTransformDict(collections.abc.MutableMapping):
     """
     A dict-like object that transforms its keys for internal storage,
     allowing non-hashable keys to be used efficiently.

--- a/refcycle/test/test_object_graph.py
+++ b/refcycle/test/test_object_graph.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import collections
+import collections.abc
 import gc
 import json
 import os
@@ -531,9 +531,9 @@ class TestObjectGraph(unittest.TestCase):
     def test_abstract_bases(self):
         graph = ObjectGraph()
         self.assertIsInstance(graph, IDirectedGraph)
-        self.assertIsInstance(graph, collections.Sized)
-        self.assertIsInstance(graph, collections.Iterable)
-        self.assertIsInstance(graph, collections.Container)
+        self.assertIsInstance(graph, collections.abc.Sized)
+        self.assertIsInstance(graph, collections.abc.Iterable)
+        self.assertIsInstance(graph, collections.abc.Container)
 
     @unittest.skipUnless(dot_available(), "Graphviz dot command not available")
     def test_export_image(self):


### PR DESCRIPTION
This PR updates imports from collections that need to be from collections.abc (since Python 3.10).

Closes #83 
