### PR TITLE
Add __builtins__ to function annotations

### DIFF
--- a/refcycle/annotations.py
+++ b/refcycle/annotations.py
@@ -58,6 +58,8 @@ def add_function_references(obj, references):
         add_attr(obj, "__qualname__", references)
         add_attr(obj, "__annotations__", references)
         add_attr(obj, "__kwdefaults__", references)
+        if hasattr(obj, "__builtins__"):
+            add_attr(obj, "__builtins__", references)
 
 
 def add_sequence_references(obj, references):


### PR DESCRIPTION
This PR fixes a test failure on Python 3.10: since Python 3.10, function objects have a `__builtins__` reference.