### PR TITLE
Fix a test failure to lazy __dict__ creation on Python >= 3.11

### DIFF
--- a/refcycle/test/test_object_graph.py
+++ b/refcycle/test/test_object_graph.py
@@ -68,8 +68,10 @@ class A(object):
 def create_cycle():
     a = A()
     b = A()
-    a.foo = b
-    b.foo = a
+    # Force __dict__ creation for Python >= 3.11, for predictability across
+    # Python versions. xref: https://github.com/python/cpython/issues/89503
+    a.__dict__["foo"] = b
+    b.__dict__["foo"] = a
 
 
 class TestObjectGraph(unittest.TestCase):

--- a/refcycle/test/test_refcycle.py
+++ b/refcycle/test/test_refcycle.py
@@ -36,8 +36,10 @@ class A(object):
 def create_cycles():
     a = A()
     b = A()
-    a.foo = b
-    b.foo = a
+    # Force __dict__ creation for Python >= 3.11, for predictability across
+    # Python versions. xref: https://github.com/python/cpython/issues/89503
+    a.__dict__["foo"] = b
+    b.__dict__["foo"] = a
 
 
 class TestRefcycle(unittest.TestCase):


### PR DESCRIPTION
This PR fixes some test failures that were due to an optimization in Python 3.11: the tests expected objects in a cycle to have a `__dict__`, but Python 3.11 introduces an optimization that creates `__dict__` lazily when needed. See python/cpython#89503.