### PR TITLE
Add build directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+/build/
+/refcycle.egg-info/


### PR DESCRIPTION
This PR adds /build/ and /refcycle.egg-info/ directories to the `.gitignore`, since they're often created during development.