### PR TITLE
Install graphviz to avoid skipping tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ jobs:
       fail-fast: false
 
     steps:
+    - run: |
+        sudo apt-get update
+        sudo apt-get install graphviz
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
The CI is currently skipping some tests, because `dot` isn't available. This PR should fix that.