### PR TITLE
Change Python version used for documentation build to Python 3.11

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.12'
+        python-version: '3.11'
         cache: 'pip'
         cache-dependency-path: 'docs/requirements.txt'
     - run: python -m pip install -r docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.11"
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
Read the Docs doesn't yet support using Python 3.12 for documentation builds; this PR changes the Python version that we're using to Python 3.11.